### PR TITLE
Changing the name of a button

### DIFF
--- a/web/html/src/manager/systems/all-list.test.tsx
+++ b/web/html/src/manager/systems/all-list.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "utils/test-utils";
+
+import { AllSystems } from "./all-list";
+
+jest.mock("components/table/Table", () => ({
+  Table: ({ titleButtons }) => <div>{titleButtons}</div>,
+}));
+
+describe("AllSystems", () => {
+  test('renders "New system" action button', () => {
+    render(<AllSystems docsLocale="en" isAdmin />);
+
+    const newSystemLink = screen.getByRole("link", { name: "New system" });
+    expect(newSystemLink.getAttribute("href")).toBe("/rhn/manager/systems/bootstrap");
+    expect(screen.queryByRole("link", { name: "Add new system" })).toBeNull();
+  });
+});

--- a/web/html/src/manager/systems/all-list.tsx
+++ b/web/html/src/manager/systems/all-list.tsx
@@ -66,7 +66,7 @@ export function AllSystems(props: Props) {
             id="addsystem"
             icon="fa-plus"
             className="btn btn-primary"
-            text={t("New system")}
+            text={t("Add new system")}
             href="/rhn/manager/systems/bootstrap"
           />
         </div>

--- a/web/html/src/manager/systems/all-list.tsx
+++ b/web/html/src/manager/systems/all-list.tsx
@@ -66,7 +66,7 @@ export function AllSystems(props: Props) {
             id="addsystem"
             icon="fa-plus"
             className="btn btn-primary"
-            text={t("Add system")}
+            text={t("New system")}
             href="/rhn/manager/systems/bootstrap"
           />
         </div>

--- a/web/html/src/manager/systems/all-list.tsx
+++ b/web/html/src/manager/systems/all-list.tsx
@@ -66,7 +66,7 @@ export function AllSystems(props: Props) {
             id="addsystem"
             icon="fa-plus"
             className="btn btn-primary"
-            text={t("Add new system")}
+            text={t("New system")}
             href="/rhn/manager/systems/bootstrap"
           />
         </div>


### PR DESCRIPTION
## What does this PR change?

This pull request makes a minor wording update to the "Add system" button in the `AllSystems` component. The button label now reads "New system" instead of "Add system".


- [x] No changelog needed
